### PR TITLE
fix: call-kis-api params가 JSON 문자열로 전달돼도 파싱하도록 fallback 추가

### DIFF
--- a/server.py
+++ b/server.py
@@ -767,14 +767,32 @@ def _default_param_value(name: str, wire_name: str) -> tuple[bool, Any]:
     return False, None
 
 
+def _coerce_params_argument(params: dict[str, Any] | str | None) -> dict[str, Any]:
+    """일부 MCP 클라이언트는 params 객체를 JSON 문자열로 직렬화해 보내므로 파싱 fallback을 둔다."""
+    if params is None:
+        return {}
+    if isinstance(params, dict):
+        return params
+    if isinstance(params, str):
+        text = params.strip()
+        if not text:
+            return {}
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"params must be a JSON object/dict, got unparseable string: {e}") from e
+        if not isinstance(parsed, dict):
+            raise ValueError("params must be a JSON object/dict")
+        return parsed
+    raise ValueError("params must be an object/dict")
+
+
 def _prepare_api_payload(
     spec: dict[str, Any],
-    params: dict[str, Any] | None,
+    params: dict[str, Any] | str | None,
     allow_extra_params: bool = False,
 ) -> dict[str, Any]:
-    input_params = params or {}
-    if not isinstance(input_params, dict):
-        raise ValueError("params must be an object/dict")
+    input_params = _coerce_params_argument(params)
 
     payload: dict[str, Any] = {}
     consumed: set[str] = set()
@@ -890,7 +908,7 @@ async def get_kis_api_spec(group: str, api_type: str):
 async def call_kis_api(
     group: str,
     api_type: str,
-    params: dict[str, Any] | None = None,
+    params: dict[str, Any] | str | None = None,
     tr_id: str | None = None,
     tr_cont: str = "",
     env_dv: str | None = None,

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -182,6 +182,34 @@ class KisRequestTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(client.calls[0]["params"]["FID_COND_MRKT_DIV_CODE"], "J")
         self.assertEqual(client.calls[0]["params"]["FID_INPUT_ISCD"], "005930")
 
+    async def test_generic_call_accepts_json_string_params(self):
+        env = {
+            "KIS_APP_KEY": "app",
+            "KIS_APP_SECRET": "secret",
+            "KIS_ACCOUNT_TYPE": "REAL",
+        }
+        client = StubClient(StubResponse({"output": {"stck_prpr": "70000"}}))
+
+        with patch.dict(os.environ, env, clear=True), \
+             patch.object(server, "get_http_client", AsyncMock(return_value=client)), \
+             patch.object(server, "get_access_token", AsyncMock(return_value="token")):
+            result = await server.call_kis_api(
+                "domestic_stock",
+                "inquire_price",
+                '{"fid_cond_mrkt_div_code": "J", "fid_input_iscd": "005930"}',
+            )
+
+        self.assertEqual(result["output"]["stck_prpr"], "70000")
+        self.assertEqual(client.calls[0]["params"]["FID_COND_MRKT_DIV_CODE"], "J")
+        self.assertEqual(client.calls[0]["params"]["FID_INPUT_ISCD"], "005930")
+
+    async def test_generic_call_rejects_non_object_string_params(self):
+        with self.assertRaisesRegex(ValueError, "params must be a JSON object"):
+            await server.call_kis_api("domestic_stock", "inquire_price", '["not", "a", "dict"]')
+
+        with self.assertRaisesRegex(ValueError, "unparseable string"):
+            await server.call_kis_api("domestic_stock", "inquire_price", "{broken json")
+
     async def test_generic_call_rejects_unknown_params_by_default(self):
         with self.assertRaisesRegex(ValueError, "Unknown params"):
             await server.call_kis_api(

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -203,6 +203,30 @@ class KisRequestTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(client.calls[0]["params"]["FID_COND_MRKT_DIV_CODE"], "J")
         self.assertEqual(client.calls[0]["params"]["FID_INPUT_ISCD"], "005930")
 
+    async def test_mcp_tool_call_accepts_json_string_params(self):
+        env = {
+            "KIS_APP_KEY": "app",
+            "KIS_APP_SECRET": "secret",
+            "KIS_ACCOUNT_TYPE": "REAL",
+        }
+        client = StubClient(StubResponse({"output": {"stck_prpr": "70000"}}))
+
+        with patch.dict(os.environ, env, clear=True), \
+             patch.object(server, "get_http_client", AsyncMock(return_value=client)), \
+             patch.object(server, "get_access_token", AsyncMock(return_value="token")):
+            result = await server.mcp.call_tool(
+                "call-kis-api",
+                {
+                    "group": "domestic_stock",
+                    "api_type": "inquire_price",
+                    "params": '{"fid_cond_mrkt_div_code": "J", "fid_input_iscd": "005930"}',
+                },
+            )
+
+        self.assertEqual(result.structured_content["output"]["stck_prpr"], "70000")
+        self.assertEqual(client.calls[0]["params"]["FID_COND_MRKT_DIV_CODE"], "J")
+        self.assertEqual(client.calls[0]["params"]["FID_INPUT_ISCD"], "005930")
+
     async def test_generic_call_rejects_non_object_string_params(self):
         with self.assertRaisesRegex(ValueError, "params must be a JSON object"):
             await server.call_kis_api("domestic_stock", "inquire_price", '["not", "a", "dict"]')


### PR DESCRIPTION
## 문제

`call-kis-api` 도구의 `params` 인자는 스키마상 `anyOf: [object, null]`로 생성되지만, 일부 MCP 클라이언트가 `anyOf` 스키마를 단순화하면서 타입 정보를 잃고 dict를 **JSON 문자열로 직렬화해 전달**합니다. 이 경우 pydantic 검증에서 `Input should be a valid dictionary (dict_type)` 오류가 발생해 도구 호출이 실패합니다.

## 변경 내용

- `call_kis_api`의 `params` 타입을 `dict[str, Any] | str | None`으로 확장 — 생성되는 스키마가 `anyOf: [object, string, null]`이 되어 문자열을 보내는 클라이언트도 검증을 통과합니다.
- `_coerce_params_argument` 헬퍼 추가 — 문자열로 들어온 `params`를 `json.loads`로 파싱하고, 빈 문자열은 빈 dict로 처리하며, 객체가 아닌 JSON(배열 등)이나 파싱 불가 문자열은 명확한 `ValueError`를 냅니다.
- 테스트 2개 추가: JSON 문자열 params 정상 처리, 비정상 문자열 거부.

## 점검 사항

- 다른 도구 인자는 모두 str/int/bool이라 동일 문제가 없습니다. dict를 받는 인자는 `call-kis-api`의 `params`가 유일합니다.
- `tr_id`, `env_dv`(`str | None`)는 문자열이 그대로 통과하고, boolean 인자는 pydantic lax 모드가 `"true"`/`"false"`를 변환합니다.

## 검증

- 전체 테스트 30건 통과 (`python -m unittest tests.test_server_config`)
- 버그 재현 케이스 그대로(params를 JSON 문자열로 전달) 실제 KIS API `domestic_stock.inquire_investor_time_by_market` 호출 → 정상 응답(`rt_cd: 0`) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)